### PR TITLE
Use archive.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Pull requests are welcome.
 
 ## Protection bypass techniques
 
-[2016: "Linux Kernel x86-64 bypass SMEP - KASLR - kptr_restric"](http://blackbunny.io/linux-kernel-x86-64-bypass-smep-kaslr-kptr_restric/) [article]
+[2016: "Linux Kernel x86-64 bypass SMEP - KASLR - kptr_restric"](https://web.archive.org/web/20170111023614/http://www.blackbunny.io/linux-kernel-x86-64-bypass-smep-kaslr-kptr_restric/) [article]
 
 [2016, KIWICON: "Practical SMEP bypass techniques on Linux" by Vitaly Nikolenko](https://cyseclabs.com/slides/smep_bypass.pdf) [slides]
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Pull requests are welcome.
 
 ## Protection bypass techniques
 
-[2016: "Linux Kernel x86-64 bypass SMEP - KASLR - kptr_restric"](https://web.archive.org/web/20170111023614/http://www.blackbunny.io/linux-kernel-x86-64-bypass-smep-kaslr-kptr_restric/) [article]
+[2016: "Linux Kernel x86-64 bypass SMEP - KASLR - kptr_restric"](https://web.archive.org/web/20171029060939/http://www.blackbunny.io/linux-kernel-x86-64-bypass-smep-kaslr-kptr_restric/) [article]
 
 [2016, KIWICON: "Practical SMEP bypass techniques on Linux" by Vitaly Nikolenko](https://cyseclabs.com/slides/smep_bypass.pdf) [slides]
 


### PR DESCRIPTION
[blackbunny.io has been down for over a year](http://web.archive.org/web/20170101000000*/http://www.blackbunny.io/linux-kernel-x86-64-bypass-smep-kaslr-kptr_restric/)

**Edit:** The archive.org page rendering was broken in `20170111023614`; but was fixed in the most recent archive `20171029060939`.