### PR TITLE
fix some old links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Pull requests are welcome.
 
 ## Books
 
-[2012: "A Guide to Kernel Exploitation: Attacking the Core" by Enrico Perla and Massimiliano Oldani](https://github.com/aozhimin/awesome-iOS-resource/blob/master/Books/A%20Guide%20to%20Kernel%20Exploitation%20Attacking%20the%20Core.pdf)
-
+2012: "A Guide to Kernel Exploitation: Attacking the Core" by Enrico Perla and Massimiliano Oldani
 
 ## Exploitation techniques
 
@@ -18,7 +17,7 @@ Pull requests are welcome.
 
 [2018: "Entering God Mode  -  The Kernel Space Mirroring Attack"](https://hackernoon.com/entering-god-mode-the-kernel-space-mirroring-attack-8a86b749545f) [article]
 
-[2018, HitB: "Mirror Mirror: Rooting Android 8 with a Kernel Space Mirroring Attack" by Wang Yong](https://conference.hitb.org/hitbsecconf2018ams/materials/D1T2%20-%20Yong%20Wang%20&%20Yang%20Song%20-%20Rooting%20Android%208%20with%20a%20Kernel%20Space%20Mirroring%20Attack.pdf) [slides]
+[2018, HitB: "Mirror Mirror: Rooting Android 8 with a Kernel Space Mirroring Attack" by Wang Yong](https://github.com/ThomasKing2014/slides/blob/master/asia-18-WANG-KSMA-Breaking-Android-kernel-isolation-and-Rooting-with-ARM-MMU-features.pdf) [slides]
 
 [2018, BlackHat: "KSMA:	Breaking	Android	kernel	isolation	and	Rooting	with	ARM	MMU	features" by Wang Yong](https://www.blackhat.com/docs/asia-18/asia-18-WANG-KSMA-Breaking-Android-kernel-isolation-and-Rooting-with-ARM-MMU-features.pdf) [slides]
 
@@ -40,13 +39,13 @@ Pull requests are welcome.
 
 [2017: "New Reliable Android Kernel Root Exploitation Techniques"](http://powerofcommunity.net/poc2016/x82.pdf) [slides]
 
-[2017: "Unleashing Use-Before-Initialization Vulnerabilities in the Linux Kernel Using Targeted Stack Spraying"](https://www.internetsociety.org/sites/default/files/ndss2017_09-2_Lu_paper.pdf) [whitepaper]
+[2017: "Unleashing Use-Before-Initialization Vulnerabilities in the Linux Kernel Using Targeted Stack Spraying"](https://www-users.cs.umn.edu/~kjlu/papers/tss.pdf) [whitepaper]
 
 [2017: "Breaking KASLR with perf" by Lizzie Dixon](https://blog.lizzie.io/kaslr-and-perf.html) [article]
 
 [2017: "Linux kernel exploit cheetsheet"](https://github.com/verctor/MyNotes/blob/master/linux/linux_kernel_exploit_cheetsheet.md) [article]
 
-[2016: "Getting Physical Extreme abuse of Intel based Paging Systems" by Nicolas Economou and Enrique Nissim](https://www.coresecurity.com/system/files/publications/2016/05/CSW2016%20-%20Getting%20Physical%20-%20Extended%20Version.pdf) [slides]
+[2016: "Getting Physical Extreme abuse of Intel based Paging Systems" by Nicolas Economou and Enrique Nissim](https://cansecwest.com/slides/2016/CSW2016_Economou-Nissim_GettingPhysical.pdf) [slides]
 
 [2016: "Linux Kernel ROP - Ropping your way to # (Part 1)" by Vitaly Nikolenko](https://www.trustwave.com/Resources/SpiderLabs-Blog/Linux-Kernel-ROP---Ropping-your-way-to---(Part-1)/) [article]
 
@@ -65,8 +64,6 @@ Pull requests are welcome.
 [2015: "From Collision To Exploitation: Unleashing Use-After-Free Vulnerabilities in Linux Kernel"](http://repository.root-me.org/Exploitation%20-%20Syst%C3%A8me/Unix/EN%20-%20From%20collision%20to%20exploitation%3A%20Unleashing%20Use-After-Free%20vulnerabilities%20in%20Linux%20Kernel.pdf) [whitepaper]
 
 [2015: "Linux Kernel Exploitation" by Patrick Biernat](http://security.cs.rpi.edu/courses/binexp-spring2015/lectures/23/13_lecture.pdf) [slides]
-
-[2013: "Kernel stack overflows (basics)" by Essa Alkuwari](https://blog.0x80.org/kernel-stack-overflows-basics/) [article]
 
 [2013, Black Hat USA: "Hacking like in the Movies: Visualizing Page Tables for Local Exploitation"](https://www.youtube.com/watch?v=Of6DemoMLaA)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pull requests are welcome.
 
 ## Books
 
-2012: "A Guide to Kernel Exploitation: Attacking the Core" by Enrico Perla and Massimiliano Oldani
+[2012: "A Guide to Kernel Exploitation: Attacking the Core" by Enrico Perla and Massimiliano Oldani](http://8.oldhacker.org/docs/A%20Guide%20to%20Kernel%20Exploitation%20Attacking%20the%20Core(1).pdf)
 
 ## Exploitation techniques
 
@@ -17,7 +17,7 @@ Pull requests are welcome.
 
 [2018: "Entering God Mode  -  The Kernel Space Mirroring Attack"](https://hackernoon.com/entering-god-mode-the-kernel-space-mirroring-attack-8a86b749545f) [article]
 
-[2018, HitB: "Mirror Mirror: Rooting Android 8 with a Kernel Space Mirroring Attack" by Wang Yong](https://github.com/ThomasKing2014/slides/blob/master/asia-18-WANG-KSMA-Breaking-Android-kernel-isolation-and-Rooting-with-ARM-MMU-features.pdf) [slides]
+[2018, HitB: "Mirror Mirror: Rooting Android 8 with a Kernel Space Mirroring Attack" by Wang Yong](https://conference.hitb.org/hitbsecconf2018ams/materials/D1T2%20-%20Yong%20Wang%20&%20Yang%20Song%20-%20Rooting%20Android%208%20with%20a%20Kernel%20Space%20Mirroring%20Attack.pdf) [slides]
 
 [2018, BlackHat: "KSMA:	Breaking	Android	kernel	isolation	and	Rooting	with	ARM	MMU	features" by Wang Yong](https://www.blackhat.com/docs/asia-18/asia-18-WANG-KSMA-Breaking-Android-kernel-isolation-and-Rooting-with-ARM-MMU-features.pdf) [slides]
 


### PR DESCRIPTION
This PR fixed old links.
below is a list of changes:


- 2012: "A Guide to Kernel Exploitation: Attacking the Core" by Enrico Perla and Massimiliano Oldani: this link is down and I cannot find any replacement, name is listed here for reference.

Links that are down and cannot find any replacement:

- 2017: "Linux kernel exploit cheetsheet"
- 2013: "Kernel stack overflows (basics)" by Essa Alkuwari

Links I updated:

- 2017: "Unleashing Use-Before-Initialization Vulnerabilities in the Linux Kernel Using Targeted Stack Spraying"
- 2018, HitB: "Mirror Mirror: Rooting Android 8 with a Kernel Space Mirroring Attack" by Wang Yong
