### PR TITLE
updated link to point to internet archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pull requests are welcome.
 
 [2018: "Linux Kernel universal heap spray" by Vitaly Nikolenko](https://cyseclabs.com/blog/linux-kernel-heap-spray) [article]
 
-[2018: "Linux-Kernel-Exploit Stack Smashing"](http://tacxingxing.com/2018/02/15/linux-kernel-exploit-stack-smashing/) [article]
+[2018: "Linux-Kernel-Exploit Stack Smashing"](https://web.archive.org/web/20190421131414/http://tacxingxing.com/2018/02/15/linux-kernel-exploit-stack-smashing/) [article]
 
 [2018: "Entering God Mode  -  The Kernel Space Mirroring Attack"](https://hackernoon.com/entering-god-mode-the-kernel-space-mirroring-attack-8a86b749545f) [article]
 
@@ -528,7 +528,7 @@ Pull requests are welcome.
 
 [2019: "Effective Static Analysis of Concurrency Use-After-Free Bugs in Linux Device Drivers"](https://hal.inria.fr/hal-02182516/document) [paper]
 
-[2019: "A gentle introduction to Linux Kernel fuzzing" by 
+[2019: "A gentle introduction to Linux Kernel fuzzing" by
 Marek Majkowski](https://blog.cloudflare.com/a-gentle-introduction-to-linux-kernel-fuzzing/) [article]
 
 [2019: "Unicorefuzz: On the Viability of Emulation for Kernelspace Fuzzing"](https://www.usenix.org/system/files/woot19-paper_maier.pdf) [paper]
@@ -813,7 +813,7 @@ https://github.com/djrbliss/libplayground
 
 [pwnable.kr tasks](http://pwnable.kr/play.php) (syscall, rootkit, softmmu, towelroot, kcrc, exynos)
 
-[RPISEC kernel labs](https://github.com/RPISEC/MBE/tree/master/src/lab10) 
+[RPISEC kernel labs](https://github.com/RPISEC/MBE/tree/master/src/lab10)
 
 https://github.com/hackedteam
 


### PR DESCRIPTION
Link to "2018: Linux-Kernel-Exploit Stack Smashing" was broken--added an internet archive link so the content is still accessible