### PR TITLE
Fix a broken link in misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,7 @@ https://github.com/hackedteam
 
 https://github.com/mncoppola/Linux-Kernel-CTF
 
-https://crowell.github.io/blog/2014/11/24/hosting-a-local-kernel-ctf-challenge/
+https://github.com/crowell/old_blog/blob/source/source/_posts/2014-11-24-hosting-a-local-kernel-ctf-challenge.markdown
 
 https://github.com/ukanth/afwall/wiki/Kernel-security
 


### PR DESCRIPTION
The link https://crowell.github.io/blog/2014/11/24/hosting-a-local-kernel-ctf-challenge/ seems to 
be broken. 

The owner of the blog had removed his blog and put all the files into another repository, which has
the same content. 
The link to that has been added in this patch.