### PR TITLE
add articles on using msg_msg for arb read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Follow [@andreyknvl](https://twitter.com/andreyknvl) on Twitter to be notified o
 
 ### Exploitation
 
+[2021: "Utilizing msg_msg Objects for Arbitrary Read and Arbitrary Write in the Linux Kernel"](https://www.willsroot.io/2021/08/corctf-2021-fire-of-salvation-writeup.html) [article] [[part2](https://syst3mfailure.io/wall-of-perdition)]
+
 [2021: "Linux Kernel Exploitation Technique: Overwriting modprobe_path"](https://lkmidas.github.io/posts/20210223-linux-kernel-pwn-modprobe/) [article]
 
 [2021: "Learning Linux Kernel Exploitation"](https://lkmidas.github.io/posts/20210123-linux-kernel-pwn-part-1/) [article] [[part 2](https://lkmidas.github.io/posts/20210128-linux-kernel-pwn-part-2/)] [[part 3](https://lkmidas.github.io/posts/20210205-linux-kernel-pwn-part-3/)]


### PR DESCRIPTION
Arbitrary read has been previously discussed by Alexander Popov in his CVE writeup on CVE-2021-26708. The first article here discusses a simple and elegant way to extend msg_msg to have arbitrary write capabilities on kmalloc 4k. The second article further extends arbitrary write capabilities across all valid msg_msg sizes. In addition to documenting exploitation techniques, both of these articles are also writeups for two CTF challenges (corCTF 2021 Fire of Salvation and corCTF 2021 Wall of Perdition).