### PR TITLE
add two repositories on kernel security learning and recent CVE exploits

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ Follow [@andreyknvl](https://twitter.com/andreyknvl) on Twitter to be notified o
 
 [2009: "Linux Kernel Heap Tampering Detection" by Larry Highsmith](http://phrack.org/archives/issues/66/15.txt) [article]
 
+
 ## Exploits
 
 https://github.com/bsauce/kernel-exploit-factory
@@ -1092,9 +1093,10 @@ https://github.com/mncoppola/Linux-Kernel-CTF
 
 https://github.com/crowell/old_blog/blob/source/source/_posts/2014-11-24-hosting-a-local-kernel-ctf-challenge.markdown
 
+
 ## Misc
 
-https://github.com/bsauce/kernel-security-learning (CTF, paper, CVE)
+https://github.com/bsauce/kernel-security-learning
 
 [2021: "The Complicated History of a Simple Linux Kernel API"](https://www.grsecurity.net/complicated_history_simple_linux_kernel_api) [article]
 

--- a/README.md
+++ b/README.md
@@ -803,8 +803,9 @@ Follow [@andreyknvl](https://twitter.com/andreyknvl) on Twitter to be notified o
 
 [2009: "Linux Kernel Heap Tampering Detection" by Larry Highsmith](http://phrack.org/archives/issues/66/15.txt) [article]
 
-
 ## Exploits
+
+https://github.com/bsauce/kernel-exploit-factory
 
 [Project Zero bug reports](https://bugs.chromium.org/p/project-zero/issues/list?can=1&q=linux%20kernel&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Summary&cells=ids&sort=-id)
 
@@ -1091,8 +1092,9 @@ https://github.com/mncoppola/Linux-Kernel-CTF
 
 https://github.com/crowell/old_blog/blob/source/source/_posts/2014-11-24-hosting-a-local-kernel-ctf-challenge.markdown
 
-
 ## Misc
+
+https://github.com/bsauce/kernel-security-learning (CTF, paper, CVE)
 
 [2021: "The Complicated History of a Simple Linux Kernel API"](https://www.grsecurity.net/complicated_history_simple_linux_kernel_api) [article]
 


### PR DESCRIPTION
The repository named kernel-security-learning contains anything about kernel security, like CTF kernel pwn & kernel exploit, kernel fuzz and kernel defense paper & kernel debugging technique & kernel CVE debug.
The repository named kernel-exploit-factory contains recent Linux kernel CVE exploit analysis report and relative debug environment. You don't need to compile Linux kernel and configure your environment anymore.