### PR TITLE
Add 2026 page-cache LPE timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See [xairy.io/trainings/](https://xairy.io/trainings/).
 	- [Exploitation](#exploitation)
 	- [Protection Bypasses](#protection-bypasses)
 - [Vulnerabilities](#vulnerabilities)
+	- [2026 Page-Cache LPE Timeline](#2026-page-cache-lpe-timeline)
 	- [Info-leaks](#info-leaks)
 	- [LPE](#lpe)
 	- [RCE](#rce)
@@ -425,6 +426,27 @@ See [xairy.io/trainings/](https://xairy.io/trainings/).
 [Assorted advisories by Gyorgy Miru and kutyacica](https://labs.taszk.io/blog/)
 
 
+### 2026 Page-Cache LPE Timeline
+
+2026-03-23: Copy Fail was reported to the Linux kernel security team. [[timeline](https://copy.fail/#timeline)]
+
+2026-04-01: The mainline fix for Copy Fail was committed as `a664bf3d603d`, reverting `algif_aead` to out-of-place operation. [[commit](https://github.com/torvalds/linux/commit/a664bf3d603d)]
+
+2026-04-29: Copy Fail was publicly disclosed: a deterministic `authencesn` + `AF_ALG` + `splice()` page-cache write primitive. [[article](https://xint.io/blog/copy-fail-linux-distributions)] [[site](https://copy.fail/)] [CVE-2026-31431]
+
+2026-05-05: The Dirty Frag `xfrm-ESP` fix landed as `f4c50a4034e6`. [[commit](https://github.com/torvalds/linux/commit/f4c50a4034e6)] [CVE-2026-43284]
+
+2026-05-07: Dirty Frag was publicly disclosed as a chained page-cache LPE across `xfrm-ESP` and `RxRPC`. [[article](https://github.com/V4bel/dirtyfrag)] [[technical writeup](https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md)] [CVE-2026-43284] [CVE-2026-43500]
+
+2026-05-10: The Dirty Frag `RxRPC` fix landed as `aa54b1d27fe0`. [[commit](https://github.com/torvalds/linux/commit/aa54b1d27fe0)] [CVE-2026-43500]
+
+2026-05-13: Fragnesia was disclosed and the upstream `skb_try_coalesce()` fix was posted, preserving `SKBFL_SHARED_FRAG` when coalescing paged frags. [[article](https://github.com/v12-security/pocs/tree/main/fragnesia)] [[patch](https://lists.openwall.net/netdev/2026/05/13/79)] [CVE-2026-46300]
+
+2026-05-13: A related `pskb_copy()` / `__pskb_copy_fclone()` shared-frag propagation fix was posted after the first Fragnesia patch missed variant paths. [[v1 patch](https://lore.kernel.org/all/agRfuVOeMI5pbHhY@v4bel/)] [[oss-sec](https://seclists.org/oss-sec/2026/q2/518)]
+
+2026-05-16: The shared-frag propagation fix reached v5 and showed that Dirty Frag/Fragnesia had many sibling variants in frag-transfer helpers: `__pskb_copy_fclone()`, `skb_shift()`, `skb_gro_receive()`, `skb_gro_receive_list()`, `tcp_clone_payload()`, and `skb_segment()`. [[v5 patch](https://lore.kernel.org/netdev/ageeJfJHwgzmKXbh@v4bel/)]
+
+
 ### Info-leaks
 
 [2025: "Vulnerabilities in the /proc Component of the CAN BCM Protocol in the Linux kernel" by Anderson Nascimento](https://allelesecurity.com/wp-content/uploads/2025/12/Presentation_307.pdf) [slides] [CVE-2023-52922] [CVE-2025-38003] [CVE-2025-38004]
@@ -487,6 +509,12 @@ See [xairy.io/trainings/](https://xairy.io/trainings/).
 
 
 ### LPE
+
+[2026: "Fragnesia" by William Bowling and V12 Security](https://github.com/v12-security/pocs/tree/main/fragnesia) [article] [[patch](https://lists.openwall.net/netdev/2026/05/13/79)] [[follow-up](https://lore.kernel.org/all/agRfuVOeMI5pbHhY@v4bel/)] [CVE-2026-46300]
+
+[2026: "Dirty Frag: Universal Linux LPE" by Hyunwoo Kim](https://github.com/V4bel/dirtyfrag) [article] [[technical writeup](https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md)] [[xfrm fix](https://github.com/torvalds/linux/commit/f4c50a4034e6)] [[rxrpc fix](https://github.com/torvalds/linux/commit/aa54b1d27fe0)] [[variant fixes](https://lore.kernel.org/netdev/ageeJfJHwgzmKXbh@v4bel/)] [CVE-2026-43284] [CVE-2026-43500]
+
+[2026: "Copy Fail: 732 Bytes to Root on Every Major Linux Distribution" by Xint Code Research Team](https://xint.io/blog/copy-fail-linux-distributions) [article] [[site](https://copy.fail/)] [[fix](https://github.com/torvalds/linux/commit/a664bf3d603d)] [CVE-2026-31431]
 
 [2026: "A Race Within A Race: Exploiting CVE-2025-38617 in Linux Packet Sockets"](https://blog.calif.io/p/a-race-within-a-race-exploiting-cve) [article] [CVE-2025-38617]
 


### PR DESCRIPTION
Title: Add 2026 page-cache LPE timeline

This adds recent Linux page-cache LPE resources to the Vulnerabilities section:

- Copy Fail / CVE-2026-31431
- Dirty Frag / CVE-2026-43284 and CVE-2026-43500
- Fragnesia / CVE-2026-46300
- follow-up shared-frag propagation fixes covering related variant paths

The new timeline highlights the May 2026 sequence around Dirty Frag and Fragnesia, including the later v5 skbuff patch that propagates `SKBFL_SHARED_FRAG` through additional
frag-transfer helpers.